### PR TITLE
use new format of datetime.fromtimestamp method

### DIFF
--- a/wj.py
+++ b/wj.py
@@ -482,7 +482,7 @@ def _fromDayToScope(timeMark, scope="d", inputMode=None):
   elif scope == "w":
     if _userTimeMode == 'Greg':
       ts = _timestampForMark(timeMark)
-      d = datetime.datetime.utcfromtimestamp(ts)
+      d = datetime.datetime.fromtimestamp(ts, datetime.UTC)
       d1 = d + datetime.timedelta(days=(-1 * d.weekday()))
       d2 = d1 + datetime.timedelta(days=6)
       if d1.year != d2.year and d.year == d1.year: d2 = d1.replace(day=31)
@@ -496,7 +496,7 @@ def _fromDayToScope(timeMark, scope="d", inputMode=None):
   elif scope == "m":
     if _userTimeMode == 'Greg':
       ts = _timestampForMark(timeMark)
-      d = datetime.datetime.utcfromtimestamp(ts)
+      d = datetime.datetime.fromtimestamp(ts, datetime.UTC)
       tm = d.timetuple()
       d1 = d + datetime.timedelta(days=(1 - tm.tm_mday))
       daysInMonth = calendar.monthrange(tm.tm_year, tm.tm_mon)[1]


### PR DESCRIPTION
Hi,
the `datetime` module has made the `datetime.datetime.utcfromtimestamp` function deprecated. So when the `wj.py` runs, it will show this warning. This PR has been fixed this problem by using the new format of function. 



```
Work Journal (wj)
/home/amir//.local/bin/wj:485: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  d = datetime.datetime.utcfromtimestamp(ts)
/home/amir//.local/bin/wj:499: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  d = datetime.datetime.utcfromtimestamp(ts)
Recent messages:
Missing messages: [1] 26 Jun 2024, [2] 27 Jun 2024, [3] 28 Jun 2024, [4] 29 Jun 2024, [5] 30 Jun 2024, [6] 24 Jun 2024 - 30 Jun 2024, [7] Jun 2024, [8] 1 Jul 2024, [9] 2 Jul 2024, [10] 3 Jul 2024, [11] 4 Jul 2024 (yesterday)
---------------------------------
Actions: [d]ay entry; [w]eek; [m]onth; [y]ear; [a]ll missing
         specify [t]ime; [o]utput; [h]elp; [q]uit.
What would you like to do? [dwmyatohq]
```
